### PR TITLE
fix: typo of the proof of proposition 5 of Division euclidienne part

### DIFF
--- a/algebre-II-notes.tex
+++ b/algebre-II-notes.tex
@@ -158,7 +158,7 @@
 	Soit $p \in A$ irréductible. On a que $<p> \neq A$ car $p$ est irréductible, donc pas inversible.
 	Si $p$ divise $ab$ et ne divise pas $a$, alors $p$ et $a$ sont premiers entre eux car $p$ est irréductible.
 	Donc tout diviseur commun de $p$ et de $c$ est soit inversible soit associé à $p$. Donc $p$ divise $c$.
-	Donc d'appres 3), $<p>$ est premier.
+	Donc d'après 3), $<p>$ est premier.
 
 	\[ ab \in <p>\quad  et \quad a \notin <b> \implies b \in <p> \implies <p> \text{ premier} \]
 


### PR DESCRIPTION
#  Fix of typo of the proof of propositiition 5 of "Division euclidienne" part

<!-- Provide a general summary of your changes in the Title above -->
<!-- Optional fields can be removed if not applicable -->

## Description

<!-- Briefly describe the purpose of this pull request. -->
Correction of the typo of the first proof of propositiition 5 of "Division euclidienne" part

## Changes Made

<!-- Summarize the changes you've made in this pull request. -->

Correction of the typo : "d'appres" -> "d'après"

## Checklist

- [x] I have self-reviewed my code
- [x] Code follows project's style guidelines
- [x] Tests added and passing
- [x] Documentation updated (if needed)

## @Mention <!-- Optional -->

@Yag000 
