### PR TITLE
fix: typo in the definition of the euclidean division

### DIFF
--- a/algebre-II-notes.tex
+++ b/algebre-II-notes.tex
@@ -76,7 +76,7 @@
 
 \begin{prop}[Division euclidienne]
 	Soit $A$ un anneau commutatif. Soient $P, Q \in A[X]$ avec $Q \neq 0$ et
-	$P$ a un coefficient dominant inversible. Alors il existe un unique couple
+	$Q$ a un coefficient dominant inversible. Alors il existe un unique couple
 	$(U, R) \in A[X] \times A[X]$ tel que:
 	\begin{itemize}
 		\item $P = UQ + R$


### PR DESCRIPTION
# Pull Request

## Description

In the definition of the euclidean division, Q shouldn't be null and Q's dominant coefficient should be inversible. But it has been stated on the poly that P 's dominant ... which is misleading!

## Changes Made

P --> Q (one iteration)

## @Mention

@Yag000 
