### PR TITLE
fix: proposition 3 of integrated polynomial

### DIFF
--- a/algebre-II-notes.tex
+++ b/algebre-II-notes.tex
@@ -96,8 +96,8 @@
 	$\mathcal{P}$ est non vide et minoré par $0$. Donc il existe $d \in \mathcal{P}$ tel que $d$ est minimal.
 	On note $Q$ un polynôme de $I$ de degré $d$. Soit $P \in I$. On réalise la division euclidienne de $P$ par $Q$:
 	\[ \exists (U, R) \in K[X] \times K[X] \mid P = UQ + R \text{ et } \deg(R) < \deg(Q) \]
-	On a que $R = P - UQ \in I$  car $I$ est un idéal. Comme $\deg(R) < d$, par définition de $d$,
-	on a que $R = 0$ car $d$ est minimal. Donc $P = UQ$ et donc $I = <Q>$.
+	On a que $R = P - UQ \in I$  car $I$ est un idéal. Comme $\deg(R) < d$ et par définition $d$ est minimal pour
+    tous les éléments non nuls, on a que $R = 0$. Donc $P = UQ$ et donc $I = <Q>$.
 \end{proof}
 
 

--- a/algebre-II-notes.tex
+++ b/algebre-II-notes.tex
@@ -96,8 +96,8 @@
 	$\mathcal{P}$ est non vide et minoré par $0$. Donc il existe $d \in \mathcal{P}$ tel que $d$ est minimal.
 	On note $Q$ un polynôme de $I$ de degré $d$. Soit $P \in I$. On réalise la division euclidienne de $P$ par $Q$:
 	\[ \exists (U, R) \in K[X] \times K[X] \mid P = UQ + R \text{ et } \deg(R) < \deg(Q) \]
-	On a que $R = P - UQ \in I$  car $I$ est un idéal, et donc $\deg(R) < d$. Par définition de $d$,
-	on a $R = 0$ car $d$ est minimal. Donc $P = UQ$ et donc $I = <Q>$.
+	On a que $R = P - UQ \in I$  car $I$ est un idéal. Comme $\deg(R) < d$, par définition de $d$,
+	on a que $R = 0$ car $d$ est minimal. Donc $P = UQ$ et donc $I = <Q>$.
 \end{proof}
 
 

--- a/algebre-II-notes.tex
+++ b/algebre-II-notes.tex
@@ -96,8 +96,8 @@
 	$\mathcal{P}$ est non vide et minoré par $0$. Donc il existe $d \in \mathcal{P}$ tel que $d$ est minimal.
 	On note $Q$ un polynôme de $I$ de degré $d$. Soit $P \in I$. On réalise la division euclidienne de $P$ par $Q$:
 	\[ \exists (U, R) \in K[X] \times K[X] \mid P = UQ + R \text{ et } \deg(R) < \deg(Q) \]
-	On a que $R = P - UQ \in I$ et donc $\deg(R) \in \mathcal{P}$. Donc $\deg(R) \geq d$ par définition de $d$.
-	Donc $\deg(R) = d$ et donc $R = 0$ car $d$ est minimal. Donc $P = UQ$ et donc $I = <Q>$.
+	On a que $R = P - UQ \in I$  car $I$ est un idéal, et donc $\deg(R) < d$. Par définition de $d$,
+	on a $R = 0$ car $d$ est minimal. Donc $P = UQ$ et donc $I = <Q>$.
 \end{proof}
 
 


### PR DESCRIPTION
# fix: proposition 3 of integrated polynomial

<!-- Provide a general summary of your changes in the Title above -->
<!-- Optional fields can be removed if not applicable -->

## Description

<!-- Briefly describe the purpose of this pull request. -->
There was a problem in the proof of the polynomial ring is integral, implies that the ring is integral, solved in this MR. The problem was due to an inconsistency in the degree of the remainder in the proof

## Changes Made

<!-- Summarize the changes you've made in this pull request. -->
The proof of proposition 3 of the section "Rings of polynomials" has been corrected.

## Related Issue <!-- Optional -->

<!-- Link to the related issue, e.g., "Closes #123" or "Fixes #456" -->
#7 

## Checklist

- [x] I have self-reviewed my code
- [x] Code follows project's style guidelines
- [x] Tests added and passing
- [x] Documentation updated (if needed)


## @Mention <!-- Optional -->

<!-- Mention specific individuals or teams for review -->
@mathusanMe @Yag000 
